### PR TITLE
handle multilayer fraglib

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,27 +44,34 @@ string(REGEX REPLACE "([^;]+)" "${src_prefix}\\1" sources_list "${raw_sources_li
 add_library(efp ${sources_list})
 set_target_properties(efp PROPERTIES POSITION_INDEPENDENT_CODE ${BUILD_FPIC}
                                      COMPILE_FLAGS "-std=c99")
-set_source_files_properties(src/int.c PROPERTIES COMPILE_FLAGS -O1)
+set_source_files_properties(${src_prefix}int.c PROPERTIES COMPILE_FLAGS -O1)
 if(${BUILD_SHARED_LIBS})
     target_link_libraries(efp PRIVATE ${LIBC_INTERJECT})
 endif()
 
+set(FRAGLIB_DATADIRS "")
 file(GLOB_RECURSE _dotefps RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} "fraglib/*.efp")
 foreach(_dotefp ${_dotefps})
+    get_filename_component(_efpdir ${_dotefp} DIRECTORY)
     get_filename_component(_efpfile ${_dotefp} NAME)
     file(READ ${_dotefp} _strefpL)
     string(REPLACE "_L" "" _strefp ${_strefpL})
 
-    if(FRAGLIB_DEEP AND FRAGLIB_UNDERSCORE_L)  # normal libefp
-        file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/${_dotefp} ${_strefpL})
-    elseif(FRAGLIB_DEEP AND NOT FRAGLIB_UNDERSCORE_L)
-        file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/${_dotefp} ${_strefp})
-    elseif(NOT FRAGLIB_DEEP AND FRAGLIB_UNDERSCORE_L)
-        file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/fraglib/${_efpfile} ${_strefpL})
-    elseif(NOT FRAGLIB_DEEP AND NOT FRAGLIB_UNDERSCORE_L)  # normal Psi4
-        file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/fraglib/${_efpfile} ${_strefp})
+    if(FRAGLIB_DEEP)
+        set(_destdir ${_efpdir})
+    else()
+        set(_destdir fraglib)
     endif()
+    if(FRAGLIB_UNDERSCORE_L)
+        set(_destcontents ${_strefpL})
+    else()
+        set(_destcontents ${_strefp})
+    endif()
+
+    list(APPEND FRAGLIB_DATADIRS ${_destdir})
+    file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/${_destdir}/${_efpfile} ${_destcontents})
 endforeach()
+list(REMOVE_DUPLICATES FRAGLIB_DATADIRS)
 
 # <<<  Install  >>>
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,7 @@ option_with_print(ENABLE_GENERIC "Enable mostly static linking in shared library
 option_with_flags(ENABLE_XHOST "Enable processor-specific optimization" ON
                   "-xHost" "-march=native")
 option_with_print(FRAGLIB_UNDERSCORE_L "Installed fragment library has names ending in _L. Psi4 wants OFF" ON)
+option_with_print(FRAGLIB_DEEP "Installed fragment libary has hierarchical, not flat, filestructure. Psi4 wants OFF" ON)
 # CODE_COVERAGE should be tested and probably propagated to external projects
 #option_with_flags(ENABLE_CODE_COVERAGE "Enables details on code coverage" OFF
 #                  "-ftest-coverage")
@@ -48,26 +49,29 @@ if(${BUILD_SHARED_LIBS})
     target_link_libraries(efp PRIVATE ${LIBC_INTERJECT})
 endif()
 
-if(NOT FRAGLIB_UNDERSCORE_L)
-    file(GLOB _dotefps RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} "fraglib/*.efp")
-    foreach(_dotefp ${_dotefps})
-        file(READ ${_dotefp} _strefpL)
-        string(REPLACE "_L" "" _strefp ${_strefpL})
+file(GLOB_RECURSE _dotefps RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} "fraglib/*.efp")
+foreach(_dotefp ${_dotefps})
+    get_filename_component(_efpfile ${_dotefp} NAME)
+    file(READ ${_dotefp} _strefpL)
+    string(REPLACE "_L" "" _strefp ${_strefpL})
+
+    if(FRAGLIB_DEEP AND FRAGLIB_UNDERSCORE_L)  # normal libefp
+        file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/${_dotefp} ${_strefpL})
+    elseif(FRAGLIB_DEEP AND NOT FRAGLIB_UNDERSCORE_L)
         file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/${_dotefp} ${_strefp})
-    endforeach()
-endif()
+    elseif(NOT FRAGLIB_DEEP AND FRAGLIB_UNDERSCORE_L)
+        file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/fraglib/${_efpfile} ${_strefpL})
+    elseif(NOT FRAGLIB_DEEP AND NOT FRAGLIB_UNDERSCORE_L)  # normal Psi4
+        file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/fraglib/${_efpfile} ${_strefp})
+    endif()
+endforeach()
 
 # <<<  Install  >>>
 
-if(FRAGLIB_UNDERSCORE_L)
-    install(DIRECTORY fraglib
-            DESTINATION ${CMAKE_INSTALL_DATADIR}/${PN})
-else()
-    install(FILES fraglib/makefp.inp
-            DESTINATION ${CMAKE_INSTALL_DATADIR}/${PN})
-    install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/fraglib
-            DESTINATION ${CMAKE_INSTALL_DATADIR}/${PN})
-endif()
+install(FILES fraglib/makefp.inp
+        DESTINATION ${CMAKE_INSTALL_DATADIR}/${PN})
+install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/fraglib
+        DESTINATION ${CMAKE_INSTALL_DATADIR}/${PN})
 
     # headers NOT namespace protected
 install(FILES ${src_prefix}/efp.h 
@@ -102,4 +106,7 @@ install(EXPORT "${PN}Targets"
 # Notes on CMake: CMake builds libefp, the shared or static library,
 #   but not efpmd because math detection would add a whole lot of extra code,
 #   and Psi4 doesn't use it. Also not implemented is testing with CTest.
+#   Another implication of no MKL math detection is that when libefp is
+#   compiled statically with OpenMP, will need to compile consuming
+#   application with OpenMP, too, or supply link library.
 

--- a/README-cmake.md
+++ b/README-cmake.md
@@ -11,7 +11,8 @@ The build is also responsive to
 - static/shared toggle `BUILD_SHARED_LIBS`
 - install location `CMAKE_INSTALL_PREFIX`
 - `name/name_L` in library fragments toggle `FRAGLIB_UNDERSCORE_L`
-- `CMAKE_Fortran_COMPILER`, `CMAKE_C_COMPILER`, and `CMAKE_Fortran_FLAGS`
+- shallow/deep library fragments directory structure toggle `FRAGLIB_DEEP`
+- `CMAKE_C_COMPILER` and `CMAKE_C_FLAGS`
 
 See [CMakeLists.txt](CMakeLists.txt) for options details and additional options.
 All these build options should be passed as `cmake -DOPTION`.

--- a/cmake/autocmake_omp.cmake
+++ b/cmake/autocmake_omp.cmake
@@ -2,6 +2,7 @@
 #   https://github.com/coderefinery/autocmake/blob/master/modules/omp.cmake
 # * moved option up
 # * toggled option default to ON
+# * reorganized logic for Fortran + C/CXX, see https://github.com/coderefinery/autocmake/issues/177
 
 #.rst:
 #
@@ -24,25 +25,6 @@
 #   define: "'-DENABLE_OPENMP={0}'.format(arguments['--omp'])"
 
 if(ENABLE_OPENMP)
-    if(DEFINED CMAKE_Fortran_COMPILER_ID)
-        # we do this in a pedestrian way because the Fortran support is relatively recent
-        if(CMAKE_Fortran_COMPILER_ID MATCHES GNU)
-            set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fopenmp")
-        endif()
-        if(CMAKE_Fortran_COMPILER_ID MATCHES Intel)
-            set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -openmp")
-        endif()
-        if(CMAKE_Fortran_COMPILER_ID MATCHES PGI)
-            set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -mp")
-        endif()
-        if(CMAKE_Fortran_COMPILER_ID MATCHES XL)
-            set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -qsmp")
-        endif()
-        if(CMAKE_Fortran_COMPILER_ID MATCHES Cray)
-            # do nothing in this case
-        endif()
-        set(OPENMP_FOUND TRUE)
-    endif()
 
     if(NOT OPENMP_FOUND)
         find_package(OpenMP)
@@ -56,5 +38,35 @@ if(ENABLE_OPENMP)
         if(DEFINED CMAKE_CXX_COMPILER_ID)
             set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
         endif()
+        if(DEFINED CMAKE_Fortran_COMPILER_ID)
+            set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} ${OpenMP_Fortran_FLAGS}")
+        endif()
+    endif()
+
+    if(DEFINED CMAKE_Fortran_COMPILER_ID AND NOT DEFINED OpenMP_Fortran_FLAGS)
+        # we do this in a pedestrian way because the Fortran support is relatively recent
+        if(CMAKE_Fortran_COMPILER_ID MATCHES GNU)
+            set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fopenmp")
+        endif()
+        if(CMAKE_Fortran_COMPILER_ID MATCHES Intel)
+            if(WIN32)
+                set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -Qopenmp")
+            elseif(CMAKE_Fortran_COMPILER_ID STREQUAL "Intel" AND
+                   "${CMAKE_Fortran_COMPILER_VERSION}" VERSION_LESS "15.0.0.20140528")
+                set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -openmp")
+            else()
+                set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -qopenmp")
+            endif()
+        endif()
+        if(CMAKE_Fortran_COMPILER_ID MATCHES PGI)
+            set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -mp")
+        endif()
+        if(CMAKE_Fortran_COMPILER_ID MATCHES XL)
+            set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -qsmp")
+        endif()
+        if(CMAKE_Fortran_COMPILER_ID MATCHES Cray)
+            # do nothing in this case
+        endif()
+        set(OPENMP_FOUND TRUE)
     endif()
 endif()

--- a/fraglib/databases/README.md
+++ b/fraglib/databases/README.md
@@ -3,8 +3,7 @@ Fragments in this directory are sufficient for the S22 and S66 databases, as rep
 * "D" means homodimer
 * EFP fragments from https://github.com/makefp/EFP_potentials/tree/master/gamess
 
-S22 Geometries from http://dx.doi.org/10.1039/b600027d
-======================================================
+### S22 Geometries from http://dx.doi.org/10.1039/b600027d
 
 * `2aminopyridine.efp` S22: 6
 * `adenine-stack.efp` S22: 15
@@ -20,8 +19,7 @@ S22 Geometries from http://dx.doi.org/10.1039/b600027d
 * `thymine-wc.efp` S22: 7
 * `uracil.efp` S22: 5D, 13D
 
-Geometries from http://dx.doi.org/10.1021/ct200673a
-===================================================
+### Geometries from http://dx.doi.org/10.1021/ct200673a
 
 * `acetamide-gp.efp` S66: 53, 62
 * `acetamide-hb.efp` S66: 21D, 23

--- a/libefpConfig.cmake.in
+++ b/libefpConfig.cmake.in
@@ -61,6 +61,7 @@ set (_valid_components
 )
 
 # find includes
+unset(_temp_h CACHE)
 find_path(_temp_h
           NAMES efp.h
           PATHS ${PACKAGE_PREFIX_DIR}/@CMAKE_INSTALL_INCLUDEDIR@
@@ -84,6 +85,7 @@ if(_seek_shared GREATER -1)
 elseif(_seek_static GREATER -1)
     set(CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_STATIC_LIBRARY_SUFFIX})
 endif()
+unset(_temp CACHE)
 find_library(_temp
              NAMES efp
              PATHS ${PACKAGE_PREFIX_DIR}/@CMAKE_INSTALL_LIBDIR@

--- a/libefpConfig.cmake.in
+++ b/libefpConfig.cmake.in
@@ -13,6 +13,7 @@
 #   libefp_DEFINITIONS: Definitions necessary to use libefp, namely USING_libefp.
 #   libefp_LIBRARIES - libefp library to link against.
 #   libefp_LIBRARY - same as LIBRARIES
+#   libefp_FRAGLIB_DIRS - Directories (list) where EFP fragments are located
 #
 #
 # Available components: shared static
@@ -21,6 +22,7 @@
 #
 #   shared - search for only shared library
 #   static - search for only static library
+#   shallow - search for only fragment library where directory structure has been collapsed
 #
 #
 # Exported targets:
@@ -58,6 +60,7 @@ set(PN libefp)
 set (_valid_components
     static
     shared
+    shallow
 )
 
 # find includes
@@ -115,6 +118,20 @@ else()
 endif()
 set(CMAKE_FIND_LIBRARY_SUFFIXES ${_hold_library_suffixes})
 set(${PN}_LIBRARIES ${${PN}_LIBRARY})
+
+# find fraglibs
+list(FIND ${PN}_FIND_COMPONENTS "shallow" _seek_shallow)
+string(REGEX REPLACE "([^;]+)" "${PACKAGE_PREFIX_DIR}/@CMAKE_INSTALL_DATADIR@/${PN}/\\1" ${PN}_FRAGLIB_DIRS "@FRAGLIB_DATADIRS@")
+if(_seek_shallow GREATER -1)
+    list(LENGTH ${PN}_FRAGLIB_DIRS _temp_len)
+    if(_temp_len EQUAL 1)
+        set(${PN}_shallow_FOUND 1)
+    else()
+        if(NOT CMAKE_REQUIRED_QUIET)
+            message(STATUS "${PN}Config missing component: shallow fraglib (${PN}: ${${PN}_FRAGLIB_DIRS})")
+        endif()
+    endif()
+endif()
 
 check_required_components(${PN})
 


### PR DESCRIPTION
These are the last of the changes I foresee. Mostly, this handles keeping or collapsing the fraglib directory structure (toggle `-DFRAGLIB_DEEP`) and provides, upon import a variable `libefp_FRAGLIB_DIRS` with a list of all directories containing efp fragments for the consuming program to handle as it will. (Psi4 proceeds to symlink the lot into a place where it can find them.) The OpenMP changes are just bringing that file up to date after fixing a bug that doesn't affect libefp.

So, if you merge this in, I'll leave you alone for a while. :-) Eventually, a git tag will be useful, but I'll request that after quite sure there's no more increments.

By the way, if you envision this project to have different capitalization than `libefp`, this is the time to speak up.

Thanks!