### PR TITLE
Psi4 and CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,13 @@ include(autocmake_safeguards)
 include(autocmake_omp)
 include(autocmake_static_library)
 
+if (LAPACK_INTERJECT)
+    message (STATUS "LAPACK detection suppressed. Using: ${LAPACK_INTERJECT}")
+else()
+    find_package (LAPACK REQUIRED)
+    message (STATUS "LAPACK detected. Using: ${LAPACK_LIBRARIES}")
+endif()
+
 ################################# Main Project #################################
 include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)
@@ -56,7 +63,9 @@ set_target_properties(efp PROPERTIES POSITION_INDEPENDENT_CODE ${BUILD_FPIC}
 set_source_files_properties(${src_prefix}int.c PROPERTIES COMPILE_FLAGS -O1)
 if(${BUILD_SHARED_LIBS})
     target_link_libraries(efp PRIVATE ${LIBC_INTERJECT})
-
+    if(LAPACK_INTERJECT)
+        target_link_libraries(efp PRIVATE ${LAPACK_INTERJECT})
+    endif()
     if(APPLE)
         set_target_properties(efp PROPERTIES LINK_FLAGS "-undefined dynamic_lookup")
     endif()
@@ -104,6 +113,9 @@ install(TARGETS efp
 # <<<  Export Interface  >>>
 
 target_compile_definitions(efp INTERFACE USING_${PN})
+if(LAPACK_LIBRARIES)
+    target_link_libraries(efp INTERFACE ${LAPACK_LIBRARIES})
+endif()
 target_include_directories(efp INTERFACE
                            $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,10 +56,10 @@ set_target_properties(efp PROPERTIES POSITION_INDEPENDENT_CODE ${BUILD_FPIC}
 set_source_files_properties(${src_prefix}int.c PROPERTIES COMPILE_FLAGS -O1)
 if(${BUILD_SHARED_LIBS})
     target_link_libraries(efp PRIVATE ${LIBC_INTERJECT})
-endif()
-if(APPLE)
-    # defer linking to BLAS
-    target_link_libraries(efp PRIVATE "-undefined dynamic_lookup")
+
+    if(APPLE)
+        set_target_properties(efp PROPERTIES LINK_FLAGS "-undefined dynamic_lookup")
+    endif()
 endif()
 
 set(FRAGLIB_DATADIRS "")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,7 +109,8 @@ target_include_directories(efp INTERFACE
 
 # <<<  Export Config  >>>
 
-set(CMAKECONFIG_INSTALL_DIR "${CMAKE_INSTALL_DATADIR}/cmake/${PN}")
+    # explicit "share" not "DATADIR" for CMake search path
+set(CMAKECONFIG_INSTALL_DIR "share/cmake/${PN}")
 configure_package_config_file(${PN}Config.cmake.in
                               "${CMAKE_CURRENT_BINARY_DIR}/${PN}Config.cmake"
                               INSTALL_DESTINATION ${CMAKECONFIG_INSTALL_DIR})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,14 @@
+cmake_policy(SET CMP0048 NEW)  # project_VERSION* variables populated from project(... VERSION x.x.x) string
+project(libefp
+        VERSION 1.3.0
+        LANGUAGES C)
+set(libefp_AUTHORS      "Ilya A. Kaliman")
+set(libefp_DESCRIPTION  "Parallel implementation of the Effective Fragment Potential (EFP) method")
+#set(libefp_EMAIL
+set(libefp_URL          "https://libefp.github.io/")
+set(libefp_LICENSE      "BSD 2-clause")
+
 cmake_minimum_required(VERSION 3.0)
-project(libefp LANGUAGES C)
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
 
 ################################### Options ####################################
@@ -10,7 +19,7 @@ option_with_default(BUILD_FPIC "Libraries will be compiled with position indepen
 if(${BUILD_SHARED_LIBS} AND NOT ${BUILD_FPIC})
     message(FATAL_ERROR "BUILD_SHARED_LIBS ON and BUILD_FPIC OFF are incompatible, as shared library requires position independent code")
 endif()
-option_with_print(ENABLE_OPENMP "Enable OpenMP parallelization" ON)
+option_with_print(ENABLE_OPENMP "Enable OpenMP parallelization. Psi4 wants OFF" ON)
 option_with_print(ENABLE_GENERIC "Enable mostly static linking in shared library" OFF)
 option_with_flags(ENABLE_XHOST "Enable processor-specific optimization" ON
                   "-xHost" "-march=native")
@@ -82,7 +91,7 @@ install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/fraglib
 
     # headers NOT namespace protected
 install(FILES ${src_prefix}/efp.h 
-        DESTINATION ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_INCLUDEDIR})
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 install(TARGETS efp
         EXPORT "${PN}Targets"
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
@@ -101,7 +110,7 @@ configure_package_config_file(${PN}Config.cmake.in
                               "${CMAKE_CURRENT_BINARY_DIR}/${PN}Config.cmake"
                               INSTALL_DESTINATION ${CMAKECONFIG_INSTALL_DIR})
 write_basic_package_version_file(${CMAKE_CURRENT_BINARY_DIR}/${PN}ConfigVersion.cmake
-                                 VERSION 1.3.0
+                                 VERSION ${${PN}_VERSION}
                                  COMPATIBILITY SameMajorVersion)
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${PN}Config.cmake
               ${CMAKE_CURRENT_BINARY_DIR}/${PN}ConfigVersion.cmake

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,7 +111,7 @@ target_include_directories(efp INTERFACE
 
     # explicit "share" not "DATADIR" for CMake search path
 set(CMAKECONFIG_INSTALL_DIR "share/cmake/${PN}")
-configure_package_config_file(${PN}Config.cmake.in
+configure_package_config_file(cmake/${PN}Config.cmake.in
                               "${CMAKE_CURRENT_BINARY_DIR}/${PN}Config.cmake"
                               INSTALL_DESTINATION ${CMAKECONFIG_INSTALL_DIR})
 write_basic_package_version_file(${CMAKE_CURRENT_BINARY_DIR}/${PN}ConfigVersion.cmake

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,6 +57,10 @@ set_source_files_properties(${src_prefix}int.c PROPERTIES COMPILE_FLAGS -O1)
 if(${BUILD_SHARED_LIBS})
     target_link_libraries(efp PRIVATE ${LIBC_INTERJECT})
 endif()
+if(APPLE)
+    # defer linking to BLAS
+    target_link_libraries(efp PRIVATE "-undefined dynamic_lookup")
+endif()
 
 set(FRAGLIB_DATADIRS "")
 file(GLOB_RECURSE _dotefps RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} "fraglib/*.efp")

--- a/README-cmake.md
+++ b/README-cmake.md
@@ -24,7 +24,7 @@ This project installs with `libefpConfig.cmake`, `libefpConfigVersion.cmake`, an
 - `find_package(libefp)` - find any libefp libraries and headers
 - `find_package(libefp 1.3.0 EXACT CONFIG REQUIRED COMPONENTS static)` - find libefp exactly version 1.3.0 built with static libraries; abort on failure
 
-See [libefpConfig.cmake.in](libefpConfig.cmake.in) for details of how to detect the Config file and what CMake variables and targets are exported to your project.
+See [libefpConfig.cmake.in](cmake/libefpConfig.cmake.in) for details of how to detect the Config file and what CMake variables and targets are exported to your project.
 
 #### Using in CMake-based projects
 

--- a/cmake/Psi4Macros.cmake
+++ b/cmake/Psi4Macros.cmake
@@ -39,56 +39,6 @@ if(NOT DEFINED ${variable} OR "${${variable}}" STREQUAL "")
 endif()
 endmacro(option_with_default)
 
-#Common guts to adding a Psi4 library irrespective of bin vs. lib home
-#NOTE: list of sources is a CMake list
-#
-#Syntax general_add_library(<library name>, <list of sources>, <lib or bin>,
-#                           <dependencies>)
-#
-macro(general_add_library libname sources dir)
-   #TODO: Switch to OBJECT library?  Simplifies this macro...
-   if(${dir} MATCHES lib)
-      set(prefix lib)
-   endif()
-   add_library(${libname} ${${sources}})
-   set_target_properties(${libname} PROPERTIES 
-       POSITION_INDEPENDENT_CODE ${BUILD_FPIC}
-   )
-   install(TARGETS ${libname} DESTINATION ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR})
-   install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} 
-      DESTINATION ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_INCLUDEDIR}/psi4/src/${dir}/${prefix}${libname}
-      FILES_MATCHING PATTERN "*.h" PATTERN "*.hpp")
-   set_property(GLOBAL APPEND PROPERTY LIBLIST ${libname})
-   set(depend_name "${ARGN}")
-   foreach(name_i IN LISTS depend_name)
-      target_link_libraries(${libname} INTERFACE ${name_i})
-   endforeach()
-   target_include_directories(${libname} PUBLIC ${Boost_INCLUDE_DIRS} 
-                                                ${LIBDERIV_INCLUDE_DIRS})
-endmacro(general_add_library libname sources prefix dir)
-
-#Adds a psi4 library that lives in lib
-#
-#Syntax: psi4_add_library(<library name> <list of sources> <dependencies>)
-#
-macro(psi4_add_library libname sources)
-   general_add_library(${libname} ${sources} lib ${ARGN}) 
-endmacro(psi4_add_library libname sources)
-
-#Adds a psi4 library that lives in bin
-#
-#Syntax: psi4_add_binary(<library name> <list of sources> <dependencies>
-#
-macro(psi4_add_binary libname sources)
-   general_add_library(${libname} ${sources} bin ${ARGN})
-endmacro(psi4_add_binary libname sources)
-
-include(CheckCCompilerFlag)
-include(CheckCXXCompilerFlag)
-if(CMAKE_Fortran_COMPILER)
-    include(CheckFortranCompilerFlag)  # CMake >= 3.3, so local copy in cmake/
-endif()
-
 #The guts of the next two functions, use the wrappers please
 #
 #Syntax: add_C_or_CXX_flags(<True for C, False for CXX>)
@@ -194,18 +144,3 @@ macro(option_with_flags option msg default)
        add_flags("${ARGN}")
     endif()
 endmacro()
-
-#Macro so I don't have to look at a ton of if statements for adding each plugin
-#
-#Syntax: optional_plugin(<plugin name>)
-#
-macro(optional_plugin plugin_name)
-string(TOUPPER ${plugin_name} PLUGIN_NAME)
-if(${ENABLE_${PLUGIN_NAME}})
-   find_package(${plugin_name} REQUIRED)
-   set_property(GLOBAL APPEND PROPERTY PSI4_MODULES ${${PLUGIN_NAME}_LIBRARIES})
-   add_definitions(-DENABLE_${PLUGIN_NAME})
-else()
-   add_library(${plugin_name} INTERFACE)
-endif()
-endmacro(optional_plugin plugin_name)

--- a/cmake/Psi4Macros.cmake
+++ b/cmake/Psi4Macros.cmake
@@ -39,6 +39,12 @@ if(NOT DEFINED ${variable} OR "${${variable}}" STREQUAL "")
 endif()
 endmacro(option_with_default)
 
+include(CheckCCompilerFlag)
+include(CheckCXXCompilerFlag)
+if(CMAKE_Fortran_COMPILER)
+    include(CheckFortranCompilerFlag)  # CMake >= 3.3, so local copy in cmake/
+endif()
+
 #The guts of the next two functions, use the wrappers please
 #
 #Syntax: add_C_or_CXX_flags(<True for C, False for CXX>)

--- a/cmake/libefpConfig.cmake.in
+++ b/cmake/libefpConfig.cmake.in
@@ -118,6 +118,7 @@ else()
 endif()
 set(CMAKE_FIND_LIBRARY_SUFFIXES ${_hold_library_suffixes})
 set(${PN}_LIBRARIES ${${PN}_LIBRARY})
+set(${PN}_DEFINITIONS USING_${PN})
 
 # find fraglibs
 list(FIND ${PN}_FIND_COMPONENTS "shallow" _seek_shallow)

--- a/cmake/libefpConfig.cmake.in
+++ b/cmake/libefpConfig.cmake.in
@@ -2,9 +2,7 @@
 # ------------------
 #
 # LIBEFP cmake module.
-# This module sets the following variables in your project:
-#
-# ::
+# This module sets the following variables in your project::
 #
 #   libefp_FOUND - true if libefp and all required components found on the system
 #   libefp_VERSION - libefp version in format Major.Minor.Release
@@ -16,18 +14,14 @@
 #   libefp_FRAGLIB_DIRS - Directories (list) where EFP fragments are located
 #
 #
-# Available components: shared static
-#
-# ::
+# Available components: shared static ::
 #
 #   shared - search for only shared library
 #   static - search for only static library
 #   shallow - search for only fragment library where directory structure has been collapsed
 #
 #
-# Exported targets:
-#
-# ::
+# Exported targets::
 #
 # If libefp is found, this module defines the following :prop_tgt:`IMPORTED`
 # target. Target is shared _or_ static, so, for both, use separate, not
@@ -36,17 +30,13 @@
 #   libefp::efp - the main libefp library with header & defs attached.
 #
 #
-# Suggested usage:
-#
-# ::
+# Suggested usage::
 #
 #   find_package(libefp)
 #   find_package(libefp 1.3.0 EXACT CONFIG REQUIRED COMPONENTS shared)
 #
 #
-# The following variables can be set to guide the search for this package:
-#
-# ::
+# The following variables can be set to guide the search for this package::
 #
 #   libefp_DIR - CMake variable, set to directory containing this Config file
 #   CMAKE_PREFIX_PATH - CMake variable, set to root directory of this package

--- a/cmake/libefpConfig.cmake.in
+++ b/cmake/libefpConfig.cmake.in
@@ -7,7 +7,7 @@
 # ::
 #
 #   libefp_FOUND - true if libefp and all required components found on the system
-#   libefp_VERSION - liberp version in format Major.Minor.Release
+#   libefp_VERSION - libefp version in format Major.Minor.Release
 #   libefp_INCLUDE_DIRS - Directory where libefp header is located.
 #   libefp_INCLUDE_DIR - same as DIRS
 #   libefp_DEFINITIONS: Definitions necessary to use libefp, namely USING_libefp.


### PR DESCRIPTION
- [x] corrects installation of Config file from `CMAKE_INSTALL_DATADIR` to `cmake`
- [x] detects math libs and attaches them to libefp target
- [x] adds project info into CMake
- [x] eliminates some macros that weren't relevant to libefp

@ilyak, when you do a tag, please also bump the version near the top of the main CMakeLists.txt file.