### PR TITLE
Conversion of EFP gradient to atomic

### DIFF
--- a/src/efp.c
+++ b/src/efp.c
@@ -469,7 +469,6 @@ efp_get_atomic_gradient(struct efp *efp, double *grad)
 
 	assert(efp);
 	assert(grad);
-
 	pgrad = (vec_t *)grad;
 	
 	if (!efp->do_gradient) {

--- a/src/efp.c
+++ b/src/efp.c
@@ -31,6 +31,7 @@
 #include "elec.h"
 #include "private.h"
 #include "stream.h"
+#include "clapack.h"
 
 static void
 update_fragment(struct frag *frag)
@@ -445,6 +446,174 @@ efp_get_gradient(struct efp *efp, double *grad)
 
 	return (EFP_RESULT_SUCCESS);
 }
+
+EFP_EXPORT enum efp_result
+efp_get_atomic_gradient(struct efp *efp, double *grad)
+{
+        six_t *efpgrad; //Calculated EFP gradient
+	vec_t *pgrad; //Conversion of grad to vec_t type
+	size_t j; //Fragments iterator
+	size_t i; //Atoms in fragment iterator
+        size_t k; //First atoms of current fragment in pgrad array
+	size_t nr; //Number of atoms in the current fragment 
+	size_t maxa; //Maximum number of size of m, Ia, r arrays
+	vec_t  *r; //Radius-vector of each atom inside current fragment with respect to CoM of that fragment
+        double M, *m; //Total Mass of fragment and masses of individual atoms
+	double I, *Ia; //Inertia along axis and contribution of each individual atom
+	mat_t Id; //Total inertia tensor of fragment
+	vec_t V, G; //principal axis and Inertia along that axis
+
+	vec_t rbuf, rbuf2, tq, ri, rt; //Buffer vectors
+	size_t l; //Some additional iterator
+	double dist, sina, ft, norm; //some additional doubles
+
+	assert(efp);
+	assert(grad);
+
+	pgrad = (vec_t *)grad;
+	
+	if (!efp->do_gradient) {
+		efp_log("gradient calculation was not requested");
+		return (EFP_RESULT_FATAL);
+	}
+
+	//Copy computed efp->grad
+       	efpgrad = (six_t *)malloc(efp->n_frag * sizeof(six_t));
+	memcpy(efpgrad, efp->grad, efp->n_frag * sizeof(six_t));
+
+	//Calculate maximum size of fragment
+	maxa = 0;
+	for (j = 0; j < efp->n_frag; j++)
+		if (efp->frags[j].n_atoms > maxa) maxa=efp->frags[j].n_atoms;
+
+	//Create and initialize some arrays for work
+	r = (vec_t *)malloc(maxa * sizeof(vec_t));
+	m = (double *)malloc(maxa * sizeof(double));
+	Ia = (double *)malloc(maxa * sizeof(double));
+
+	//Main cycle (iterate fragments, distribute froces and torques)
+	k = 0;
+	for (j = 0; j < efp->n_frag; j++) {
+
+		nr = efp->frags[j].n_atoms;
+
+		//clear arrays and variables
+		memset(r, 0, maxa * sizeof(vec_t));
+		memset(m, 0, maxa * sizeof(double));
+		memset(Ia, 0, maxa * sizeof(double));
+		M = 0.0;
+		I = 0.0;
+		Id = mat_zero;
+		V = vec_zero;
+		G = vec_zero;
+
+		for (i = 0; i<nr ; i++) {
+			r[i].x = efp->frags[j].atoms[i].x - efp->frags[j].x;
+			r[i].y = efp->frags[j].atoms[i].y - efp->frags[j].y;
+			r[i].z = efp->frags[j].atoms[i].z - efp->frags[j].z;
+			m[i] = efp->frags[j].atoms[i].mass;
+			M += m[i];
+
+			//Inertia tensor contribution calculations
+			Id.xx += m[i] * (r[i].y*r[i].y + r[i].z*r[i].z);
+			Id.yy += m[i] * (r[i].x*r[i].x + r[i].z*r[i].z);
+			Id.zz += m[i] * (r[i].x*r[i].x + r[i].y*r[i].y);
+			Id.xy -= m[i] * r[i].x * r[i].y;
+			Id.yx -= m[i] * r[i].x * r[i].y;
+			Id.xz -= m[i] * r[i].x * r[i].z;
+			Id.zx -= m[i] * r[i].x * r[i].z;
+			Id.yz -= m[i] * r[i].y * r[i].z;
+			Id.zy -= m[i] * r[i].y * r[i].z;
+		}
+  
+                //Try to diagonalize Id and get principal axis
+		if (efp_dsyev('V', 'U', 3, (double *)(&Id), 3, (double *)(&G)) != 0) {
+			efp_log("Error in fragment %d : Inertia tensor diagonalization failed", j);
+			return (EFP_RESULT_FATAL);
+		}
+
+		//Add any additional forces (i.e. bonded) from grad array to efpgrad array
+		for (i = 0; i < nr; i++) {
+			//Gather Total translation
+			efpgrad[j].x += pgrad[k+i].x;
+			efpgrad[j].y += pgrad[k+i].y;
+			efpgrad[j].z += pgrad[k+i].z;
+			//Gather total Torque at CoM
+			rbuf = vec_cross(&r[i], &pgrad[k+i]);
+			efpgrad[j].a += rbuf.x;
+			efpgrad[j].b += rbuf.y;
+			efpgrad[j].c += rbuf.z;
+			//And clean grad array
+			pgrad[k+i] = vec_zero;
+		}
+
+		//Now we are ready to redistribute efpgrad over atoms
+
+		//First redistribute total translation grad[i] = m[i]/M*efpgrad[j]
+		for (i = 0; i < nr; i++) {
+			pgrad[k+i].x = efpgrad[j].x;
+			pgrad[k+i].y = efpgrad[j].y;
+			pgrad[k+i].z = efpgrad[j].z;
+			vec_scale(&pgrad[k+i], m[i]/M);
+		}
+               	
+		//Redistribution of torque should be done over 3 Principal axis copmuted previously
+		for (l = 0; l < 3; l++) {
+			
+			//copy axis vector and torque vector
+			V = ((vec_t *)&Id)[l];
+			tq.x = efpgrad[j].a;
+			tq.y = efpgrad[j].b;
+			tq.z = efpgrad[j].c;
+
+			//Calculate contribution of each atom to moment of inertia with respect to current axis
+			I = 0.0;
+			for (i = 0; i < nr; i++) {
+				rbuf = vec_cross(&V, &r[i]);
+				dist = vec_len(&rbuf);
+				Ia[i] = m[i] * dist * dist;
+				I += Ia[i];
+			}
+
+			//Project torque onto V axis
+			norm = vec_dot(&tq, &V);
+			tq = V;
+			vec_scale(&tq, norm);
+	
+			//Now distribute torque using Ia[i]/I as a scale
+			for (i = 0; i < nr; i++) {
+				//If atom is not on the current axis
+				if (!eq(Ia[i], 0.0)) {
+					//Do some strange vector stuff (should think how to make it more efficient)
+					rbuf = tq;
+					vec_scale(&rbuf, Ia[i]/I);
+					ft = vec_len(&rbuf);
+					ri = r[i];
+					vec_normalize(&ri);
+					rt = tq;
+					vec_normalize(&rt);
+					rbuf2 = vec_cross(&rt, &ri);
+					sina = vec_len(&rbuf2);
+					vec_normalize(&rbuf2);
+					vec_scale(&rbuf2, ft/sina/vec_len(&r[i]));
+					//Update grad with torque contribution of atom i over axis V
+					pgrad[k+i] = vec_add(&pgrad[k+i], &rbuf2);
+				}
+			}
+			
+		}
+
+		k += nr;
+	} //End of Main cycle
+
+	free(r);
+	free(m);
+	free(Ia);
+	free(efpgrad);
+
+	return (EFP_RESULT_SUCCESS);
+}
+
 
 EFP_EXPORT enum efp_result
 efp_set_point_charges(struct efp *efp, size_t n_ptc, const double *ptc, const double *xyz)

--- a/src/efp.h
+++ b/src/efp.h
@@ -863,6 +863,23 @@ enum efp_result efp_get_energy(struct efp *efp, struct efp_energy *energy);
 enum efp_result efp_get_gradient(struct efp *efp, double *grad);
 
 /**
+ * Get computed EFP energy gradient.
+ *
+ * \param[in] efp The efp structure.
+ *
+ * \param[out] grad For each atom fragments \a x \a y \a z components of negative
+ * force will be written to this array. The size of this array must
+ * be at least [3 * \a n] elements, where \a n is the total number of atoms ia all
+ * fragments. Atom is a point inside fragment with non-zero mass.
+ * Any gradients from that array at the begining will be gathered on the fragments  
+ * and then redistributed back to atoms. Use this for other interactions than EFP
+ * i.e. bonded forces from MM forcefield
+ *
+ * \return ::EFP_RESULT_SUCCESS on success or error code otherwise.
+ */
+enum efp_result efp_get_atomic_gradient(struct efp *efp, double *grad);
+	
+/**
  * Get the number of fragments in this computation.
  *
  * \param[in] efp The efp structure.


### PR DESCRIPTION
I've added new function to efp.c called efp_get_atomic_gradient
It returns gradient on individual atoms of fragment by distributing translation and torque.
It also can take any additional gradients on atoms (i.e. from bonded interactions) and redistribute them.

Code should be thread and mpi safe since it is purely serial.